### PR TITLE
Force Select re-rerender with key.

### DIFF
--- a/app/movies/_components/MovieFilterForm.tsx
+++ b/app/movies/_components/MovieFilterForm.tsx
@@ -24,6 +24,7 @@ type Props = {
 
 export default function MovieFilterForm({ genres }: Props) {
   const form = useFormContext<MovieFilters>();
+  const EMPTY_KEY = "empty"
 
   return (
     <form
@@ -51,7 +52,7 @@ export default function MovieFilterForm({ genres }: Props) {
             <FormLabel>Type</FormLabel>
             <FormControl>
               <Select 
-                 key={field.value ?? "empty"}
+                 key={field.value ?? EMPTY_KEY}
                  onValueChange={field.onChange} 
                  defaultValue={field.value}>
                 <SelectTrigger className="w-full">
@@ -78,7 +79,7 @@ export default function MovieFilterForm({ genres }: Props) {
             <FormLabel>Max runtime</FormLabel>
             <FormControl>
               <Select
-                key={field.value ?? "empty"}
+                key={field.value ?? EMPTY_KEY}
                 onValueChange={field.onChange}
                 defaultValue={field.value ? String(field.value) : undefined}
               >
@@ -135,7 +136,7 @@ export default function MovieFilterForm({ genres }: Props) {
             <FormLabel>Genre</FormLabel>
             <FormControl>
               <Select 
-                 key={field.value ?? "empty"} 
+                 key={field.value ?? EMPTY_KEY} 
                  onValueChange={field.onChange} 
                  defaultValue={field.value}>
                 <SelectTrigger className="w-full">
@@ -162,7 +163,7 @@ export default function MovieFilterForm({ genres }: Props) {
             <FormLabel>Stars</FormLabel>
             <FormControl>
               <Select
-                key={field.value ?? "empty"} 
+                key={field.value ?? EMPTY_KEY} 
                 onValueChange={field.onChange}
                 defaultValue={field.value?.toString()}
               >

--- a/app/movies/_components/MovieFilterForm.tsx
+++ b/app/movies/_components/MovieFilterForm.tsx
@@ -50,7 +50,10 @@ export default function MovieFilterForm({ genres }: Props) {
           <FormItem className="flex grow flex-col">
             <FormLabel>Type</FormLabel>
             <FormControl>
-              <Select onValueChange={field.onChange} defaultValue={field.value}>
+              <Select 
+                 key={field.value ?? "empty"}
+                 onValueChange={field.onChange} 
+                 defaultValue={field.value}>
                 <SelectTrigger className="w-full">
                   <SelectValue placeholder="Type" />
                 </SelectTrigger>
@@ -75,6 +78,7 @@ export default function MovieFilterForm({ genres }: Props) {
             <FormLabel>Max runtime</FormLabel>
             <FormControl>
               <Select
+                key={field.value ?? "empty"}
                 onValueChange={field.onChange}
                 defaultValue={field.value ? String(field.value) : undefined}
               >
@@ -130,7 +134,10 @@ export default function MovieFilterForm({ genres }: Props) {
           <FormItem className="flex grow flex-col">
             <FormLabel>Genre</FormLabel>
             <FormControl>
-              <Select onValueChange={field.onChange} defaultValue={field.value}>
+              <Select 
+                 key={field.value ?? "empty"} 
+                 onValueChange={field.onChange} 
+                 defaultValue={field.value}>
                 <SelectTrigger className="w-full">
                   <SelectValue placeholder="Genre" />
                 </SelectTrigger>
@@ -155,6 +162,7 @@ export default function MovieFilterForm({ genres }: Props) {
             <FormLabel>Stars</FormLabel>
             <FormControl>
               <Select
+                key={field.value ?? "empty"} 
                 onValueChange={field.onChange}
                 defaultValue={field.value?.toString()}
               >

--- a/package-lock.json
+++ b/package-lock.json
@@ -2200,6 +2200,7 @@
       "version": "19.0.2",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.0.2.tgz",
       "integrity": "sha512-USU8ZI/xyKJwFTpjSVIrSeHBVAGagkHQKPNbxeWwql/vDmnTIBgx+TJnhFnj1NXgz8XfprU0egV2dROLGpsBEg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -2209,7 +2210,7 @@
       "version": "19.0.2",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.0.2.tgz",
       "integrity": "sha512-c1s+7TKFaDRRxr1TxccIX2u7sfCnc3RxkVyBIUA2lCpyqCF+QoAwQ/CBg7bsMdVwP120HEH143VQezKtef5nCg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.0.0"
@@ -3370,6 +3371,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {


### PR DESCRIPTION
## O que foi feito

Adicionada a prop `key` ao componente `Select` para forçar o re-render quando o `value` for redefinido para `undefined` via `form.reset()`.

## Contexto

Ao utilizar `form.reset()` no React Hook Form, o valor do campo `Select` voltava para `undefined`, mas o componente `Select` (shadcn/ui) **não atualizava visualmente**, ou seja, o placeholder não era reexibido como esperado.

Ao forçar a re-renderização com `key={field.value ?? 'empty'}`, o `Select` passa a refletir corretamente o estado atual do campo após o reset.
